### PR TITLE
Add macros calculator feature

### DIFF
--- a/src/features/formulas/macros/MacrosPage.module.scss
+++ b/src/features/formulas/macros/MacrosPage.module.scss
@@ -1,0 +1,31 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-primary-100);
+}
+
+.main {
+  flex: 1;
+  padding: 1rem;
+}
+
+.heading {
+  @include heading;
+}
+
+.form {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: start;
+  gap: 4rem;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/features/formulas/macros/MacrosPage.tsx
+++ b/src/features/formulas/macros/MacrosPage.tsx
@@ -1,0 +1,56 @@
+import Navbar from "@/components/layout/Navbar/Navbar";
+import MacrosForm from "./components/MacrosForm/MacrosForm";
+import clsx from "clsx";
+import styles from "./MacrosPage.module.scss";
+import { useTheme } from "@/components/providers/ThemeProvider/ThemeProvider";
+import CalculatorResults from "../components/CalculatorResults/CalculatorResults";
+import { useState } from "react";
+import Card from "@/components/ui/Card/Card";
+
+export type MacroResults = {
+  protein: number;
+  fats: number;
+  carbs: number;
+};
+
+const MacrosPage = () => {
+  const { theme } = useTheme();
+  const [macros, setMacros] = useState<MacroResults | null>(null);
+
+  return (
+    <div className={clsx(styles.page)}>
+      <Navbar />
+      <main className={clsx(styles.main)}>
+        <h1 className={clsx(styles.heading, theme === "dark" && styles.dark)}>
+          Macronutrient Calculator
+        </h1>
+        <div className={styles.form}>
+          <Card>
+            <MacrosForm setMacros={setMacros} />
+          </Card>
+          {macros && (
+            <div className={styles.results}>
+              <CalculatorResults
+                result={macros.protein.toString()}
+                label="Protein"
+                unit="g"
+              />
+              <CalculatorResults
+                result={macros.fats.toString()}
+                label="Fats"
+                unit="g"
+              />
+              <CalculatorResults
+                result={macros.carbs.toString()}
+                label="Carbs"
+                unit="g"
+              />
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default MacrosPage;

--- a/src/features/formulas/macros/components/MacrosForm/MacrosForm.module.scss
+++ b/src/features/formulas/macros/components/MacrosForm/MacrosForm.module.scss
@@ -1,0 +1,19 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 300px;
+  max-width: 500px;
+  gap: 1rem;
+}
+
+.input,
+.select {
+  @include input;
+}
+
+.btnPrimary {
+  @include btnPrimary;
+}

--- a/src/features/formulas/macros/components/MacrosForm/MacrosForm.tsx
+++ b/src/features/formulas/macros/components/MacrosForm/MacrosForm.tsx
@@ -1,0 +1,110 @@
+import { calculateMacros } from "@/utils/coreFunctions/macros";
+import { MacroInput } from "@/utils/coreFunctions/macros/types";
+import { useForm, useStore } from "@tanstack/react-form";
+import clsx from "clsx";
+import styles from "./MacrosForm.module.scss";
+import InputField from "@/components/ui/Input/InputField";
+import SelectField from "@/components/ui/Select/SelectField";
+import type { MacroResults } from "../../MacrosPage";
+
+type MacrosFormProps = {
+  setMacros: (macros: MacroResults) => void;
+};
+
+const MacrosForm = ({ setMacros }: MacrosFormProps) => {
+  const form = useForm({
+    defaultValues: {
+      weight: 80,
+      totalCalories: 2500,
+      proteinPerKg: 2.0,
+      fatPercent: 0.25,
+      unit: "metric" as MacroInput["unit"],
+    } satisfies MacroInput,
+    onSubmit: async ({ value }) => {
+      const macros = calculateMacros(value);
+      setMacros(macros);
+    },
+  });
+
+  const unit = useStore(form.store, (state) => state.values.unit);
+  const weightUnit = unit === "metric" ? "kg" : "lbs";
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void form.handleSubmit();
+      }}
+      className={clsx(styles.form)}
+    >
+      <form.Field name="weight">
+        {(field) => (
+          <InputField
+            type="number"
+            label="Weight"
+            placeholder="Enter weight"
+            value={field.state.value}
+            unit={weightUnit}
+            onChange={(val) => field.handleChange(Number(val))}
+          />
+        )}
+      </form.Field>
+
+      <form.Field name="totalCalories">
+        {(field) => (
+          <InputField
+            type="number"
+            label="Total Calories"
+            placeholder="Enter calories"
+            value={field.state.value}
+            onChange={(val) => field.handleChange(Number(val))}
+          />
+        )}
+      </form.Field>
+
+      <form.Field name="proteinPerKg">
+        {(field) => (
+          <InputField
+            type="number"
+            label="Protein per kg"
+            placeholder="g/kg"
+            value={field.state.value}
+            onChange={(val) => field.handleChange(Number(val))}
+          />
+        )}
+      </form.Field>
+
+      <form.Field name="fatPercent">
+        {(field) => (
+          <InputField
+            type="number"
+            label="Fat % of calories"
+            placeholder="0-1"
+            value={field.state.value}
+            onChange={(val) => field.handleChange(Number(val))}
+          />
+        )}
+      </form.Field>
+
+      <form.Field name="unit">
+        {(field) => (
+          <SelectField
+            label="Unit"
+            value={field.state.value || "metric"}
+            onChange={(val) => field.handleChange(val as MacroInput["unit"])}
+            options={[
+              { value: "metric", label: "Metric (kg)" },
+              { value: "imperial", label: "Imperial (lbs)" },
+            ]}
+          />
+        )}
+      </form.Field>
+
+      <button type="submit" className={clsx(styles.btnPrimary)}>
+        Calculate Macros
+      </button>
+    </form>
+  );
+};
+
+export default MacrosForm;

--- a/src/routes/dashboard/(macros)/macros.lazy.tsx
+++ b/src/routes/dashboard/(macros)/macros.lazy.tsx
@@ -1,8 +1,6 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import MifflinStJeorPage from "../../../features/formulas/bmr/Mifflin/MifflinStJeorPage";
+import MacrosPage from "../../../features/formulas/macros/MacrosPage";
 
-export const Route = createLazyFileRoute(
-  "/dashboard/(bmr-mifflin) copy 3/bmr-mifflin"
-)({
-  component: MifflinStJeorPage,
+export const Route = createLazyFileRoute("/dashboard/(macros)/macros")({
+  component: MacrosPage,
 });


### PR DESCRIPTION
## Summary
- create a macros calculator with form and page components
- fix the `(macros)` route to load the new page

## Testing
- `npx vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849446d34e483269d4fe9d87c0b4a7d