### PR TITLE
Update styles to use new color tokens

### DIFF
--- a/src/components/layout/Navbar/Navbar.module.scss
+++ b/src/components/layout/Navbar/Navbar.module.scss
@@ -4,13 +4,13 @@
 .navbar {
   width: 100%;
   height: 3.5rem;
-  background-color: var(--secondary-800);
+  background-color: var(--color-surface);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   display: flex;
   justify-content: center;
   align-items: center;
   &.dark {
-    background-color: var(--secondary-100);
+    background-color: var(--color-surface);
   }
 }
 
@@ -32,11 +32,11 @@
   transform: translateY(-50%);
   font-weight: bold;
   font-size: 1.5rem;
-  color: var(--primary-800);
+  color: var(--color-text);
   text-decoration: none;
   align-self: baseline;
   &:hover {
-    color: var(--primary-200);
+    color: var(--color-accent);
   }
 }
 
@@ -46,36 +46,36 @@
   gap: 1.5rem;
   padding: 0;
   a {
-    color: var(--primary-800);
+    color: var(--color-text);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.2s ease-in-out;
 
     &:hover {
-      color: var(--primary-200);
+      color: var(--color-accent);
     }
   }
 }
 
 .active {
-  color: var(--primary-800);
-  border-bottom: 2px solid var(--primary-800);
+  color: var(--color-text);
+  border-bottom: 2px solid var(--color-text);
   &:hover {
-    color: var(--primary-200);
-    border-bottom: 2px solid var(--primary-200);
+    color: var(--color-accent);
+    border-bottom: 2px solid var(--color-accent);
   }
 }
 
 .themeToggle {
-  color: var(--primary-800) !important;
-  border: 1px solid var(--primary-800) !important;
+  color: var(--color-text) !important;
+  border: 1px solid var(--color-text) !important;
   position: absolute;
   right: 1rem;
   top: 50%;
   transform: translateY(-50%);
   &:hover {
-    color: var(--primary-800) !important;
-    background-color: var(--primary-200) !important;
-    border: 1px solid var(--primary-200) !important;
+    color: var(--color-text) !important;
+    background-color: var(--color-background) !important;
+    border: 1px solid var(--color-background) !important;
   }
 }

--- a/src/components/ui/Card/Card.module.scss
+++ b/src/components/ui/Card/Card.module.scss
@@ -1,16 +1,17 @@
 .card {
-  background-color: var(--color-primary-50);
+  background-color: var(--color-surface);
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
   transition: all 0.3s ease-in-out;
-  border: 1px solid var(--color-primary-100);
+  border: 1px solid var(--color-border);
 }
 
 .title {
   font-size: 1.25rem;
   font-weight: 600;
   margin-bottom: 1rem;
+  color: var(--color-text);
 }
 
 .content {

--- a/src/components/ui/Input/InputField.module.scss
+++ b/src/components/ui/Input/InputField.module.scss
@@ -12,7 +12,7 @@
 .label {
   font-size: 14px;
   font-weight: 700;
-  color: var(--color-secondary-800);
+  color: var(--color-text-muted);
 }
 
 .inputWrapper {
@@ -30,7 +30,7 @@
     right: 12px;
     top: 50%;
     font-size: 14px;
-    color: var(--color-secondary-800);
+    color: var(--color-text-muted);
     pointer-events: none;
   }
 }

--- a/src/components/ui/Select/SelectField.module.scss
+++ b/src/components/ui/Select/SelectField.module.scss
@@ -13,7 +13,7 @@
 .label {
   font-size: 14px;
   font-weight: 700;
-  color: var(--color-secondary-800);
+  color: var(--color-text-muted);
 }
 
 .selectWrapper {
@@ -37,7 +37,7 @@
     right: 0.75rem;
     top: 50%;
     transform: translateY(-50%);
-    color: var(--color-secondary-800);
+    color: var(--color-text-muted);
     pointer-events: none;
   }
 
@@ -47,8 +47,8 @@
     width: 100%;
     max-height: 200px;
     overflow-y: auto;
-    background-color: var(--color-primary-50);
-    border: 1px solid #ccc;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     z-index: 1000;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
@@ -59,16 +59,16 @@
       cursor: pointer;
       font-size: 14px;
       text-decoration: none;
-      color: var(--color-secondary-800);
+      color: var(--color-text);
       list-style-type: none;
 
       &:hover {
-        background-color: var(--color-primary-100);
+        background-color: var(--color-background);
       }
 
       &.selected {
-        background-color: var(--color-secondary-200);
-        color: var(--color-primary-500);
+        background-color: var(--color-background);
+        color: var(--color-accent);
 
         font-weight: 700;
       }

--- a/src/features/formulas/bmr/Katch/KatchMcArdlePage.module.scss
+++ b/src/features/formulas/bmr/Katch/KatchMcArdlePage.module.scss
@@ -4,7 +4,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: var(--color-primary-100);
+  background-color: var(--color-background);
 }
 
 .main {

--- a/src/features/formulas/bmr/Mifflin/MifflinStJeorPage.module.scss
+++ b/src/features/formulas/bmr/Mifflin/MifflinStJeorPage.module.scss
@@ -4,7 +4,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: var(--color-primary-100);
+  background-color: var(--color-background);
 }
 
 .main {

--- a/src/features/formulas/bodyComposition/BodyCompositionPage.module.scss
+++ b/src/features/formulas/bodyComposition/BodyCompositionPage.module.scss
@@ -4,7 +4,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: var(--color-primary-100);
+  background-color: var(--color-background);
 }
 
 .main {

--- a/src/features/formulas/components/CalculatorResults/CalculatorResults.module.scss
+++ b/src/features/formulas/components/CalculatorResults/CalculatorResults.module.scss
@@ -6,13 +6,13 @@
 .label {
   font-size: 1.5rem;
   font-weight: 800;
-  color: var(--color-primary-500);
+  color: var(--color-accent);
   margin: 0;
 }
 .result {
   font-size: 1.5rem;
   font-weight: 600;
-  color: var(--color-primary-500);
+  color: var(--color-accent);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -20,6 +20,6 @@
   span {
     font-size: 2.5rem;
     font-weight: 800;
-    color: var(--color-secondary-700);
+    color: var(--color-text);
   }
 }

--- a/src/features/formulas/macros/MacrosPage.module.scss
+++ b/src/features/formulas/macros/MacrosPage.module.scss
@@ -4,7 +4,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: var(--color-primary-100);
+  background-color: var(--color-background);
 }
 
 .main {

--- a/src/features/formulas/tdee/TDEEPage.module.scss
+++ b/src/features/formulas/tdee/TDEEPage.module.scss
@@ -4,7 +4,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: var(--color-primary-100);
+  background-color: var(--color-background);
 }
 
 .main {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -10,15 +10,15 @@
   padding: 0.75rem;
   border: none;
   border-radius: 0.375rem;
-  background-color: var(--color-primary-500);
-  color: var(--color-primary-50);
+  background-color: var(--color-accent);
+  color: var(--color-surface);
   font-weight: 600;
   cursor: pointer;
   text-align: center;
   width: 100%;
   transition: background-color 0.3s ease, color 0.3s ease;
   &:hover {
-    background-color: var(--secondary-700);
+    background-color: var(--primary-600);
   }
 }
 
@@ -27,14 +27,14 @@
   border: none;
   border-radius: 0.375rem;
   background-color: var(--color-secondary-500);
-  color: var(--color-primary-50);
+  color: var(--color-surface);
   font-weight: 600;
   cursor: pointer;
   text-align: center;
   width: 100%;
   transition: background-color 0.3s ease, color 0.3s ease;
   &:hover {
-    background-color: var(--color-primary-500);
+    background-color: var(--color-accent);
   }
 }
 
@@ -43,8 +43,8 @@
   border: none;
   border-radius: 0.375rem;
   background-color: transparent;
-  color: var(--color-primary-500);
-  border: 1px solid var(--color-primary-500);
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
   font-weight: 600;
   cursor: pointer;
   text-align: center;
@@ -52,18 +52,18 @@
   transition: background-color 0.3s ease, color 0.3s ease;
 
   &:hover {
-    background-color: var(--color-primary-500);
-    color: var(--color-primary-50);
+    background-color: var(--color-accent);
+    color: var(--color-surface);
   }
 }
 
 @mixin input {
   padding: 0.5rem;
   border-radius: 0.375rem;
-  border: 1px solid var(--color-secondary-800);
+  border: 1px solid var(--color-border);
   font-size: 1rem;
-  color: var(--color-secondary-800);
-  background-color: var(--color-background);
+  color: var(--color-text);
+  background-color: var(--color-surface);
   min-width: 200px;
   width: 100%;
 }
@@ -73,9 +73,9 @@
   font-size: 1.5rem;
   font-weight: bold;
   margin-bottom: 1.5rem;
-  color: var(--color-secondary-800);
+  color: var(--color-text);
 
   &.dark {
-    color: var(--color-secondary-200);
+    color: var(--color-text);
   }
 }


### PR DESCRIPTION
## Summary
- refactor global mixins to use new color variables
- update card, input and select components
- adjust navbar and calculator pages for base background/text colors
- apply accent and text variables to result display

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684eea5a86ec8326942d6f772b23f33d