### PR TITLE
Add flip card results for calculators

### DIFF
--- a/src/features/formulas/bmr/Katch/KatchMcArdlePage.module.scss
+++ b/src/features/formulas/bmr/Katch/KatchMcArdlePage.module.scss
@@ -7,19 +7,54 @@
   background-color: var(--color-background);
 }
 
+
 .main {
   flex: 1;
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
 }
 
 .heading {
   @include heading;
 }
 
-.form {
+.btnOutline {
+  @include btnOutline;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  min-height: 420px;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.face {
+  position: absolute;
+  width: 100%;
+  backface-visibility: hidden;
+  top: 0;
+  left: 0;
+  background: var(--color-background);
+  border-radius: 1rem;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.back {
+  transform: rotateY(180deg);
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: start;
-  gap: 4rem;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-background);
+  padding: 2rem;
+  border-radius: 1rem;
+  z-index: 1;
+}
+
+.front {
+  z-index: 2;
 }

--- a/src/features/formulas/bmr/Katch/KatchMcArdlePage.tsx
+++ b/src/features/formulas/bmr/Katch/KatchMcArdlePage.tsx
@@ -1,15 +1,20 @@
 import Navbar from "@/components/layout/Navbar/Navbar";
 import KatchMcArdleForm from "./components/KatchMcArdleForm/KatchMcArdleForm";
+import UserValues from "./components/UserValues/UserValues";
 import clsx from "clsx";
 import styles from "./KatchMcArdlePage.module.scss";
 import { useTheme } from "@/components/providers/ThemeProvider/ThemeProvider";
 import CalculatorResults from "../../components/CalculatorResults/CalculatorResults";
 import { useState } from "react";
-import Card from "@/components/ui/Card/Card";
+import { motion } from "framer-motion";
+import type { KatchMcArdleInput } from "@/utils/coreFunctions/bmr/types";
 
 const KatchMcArdlePage = () => {
   const { theme } = useTheme();
   const [bmr, setBmr] = useState<number>(0);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [formValues, setFormValues] = useState<KatchMcArdleInput | null>(null);
+
   return (
     <div className={clsx(styles.page)}>
       <Navbar />
@@ -17,18 +22,40 @@ const KatchMcArdlePage = () => {
         <h1 className={clsx(styles.heading, theme === "dark" && styles.dark)}>
           Katch-McArdle BMR Calculator
         </h1>
-        <div className={styles.form}>
-          <Card>
-            <KatchMcArdleForm setBmr={setBmr} />
-          </Card>
-          {bmr !== 0 && (
-            <CalculatorResults
-              result={bmr.toString()}
-              label="BMR"
-              unit="kcal"
+
+        <motion.div
+          className={clsx(styles.card)}
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className={clsx(styles.face, styles.front)}>
+            <KatchMcArdleForm
+              onCalculate={(bmr, values) => {
+                setFormValues(values);
+                setBmr(bmr);
+                setIsFlipped(true);
+              }}
+              onClear={() => {
+                setBmr(0);
+                setFormValues(null);
+                setIsFlipped(false);
+              }}
             />
+          </div>
+
+          {formValues && (
+            <div className={clsx(styles.face, styles.back)}>
+              <UserValues values={formValues} />
+              <CalculatorResults result={bmr.toString()} label="BMR" unit="kcal" />
+              <button
+                onClick={() => setIsFlipped(false)}
+                className={clsx(styles.btnOutline)}
+              >
+                Go Back
+              </button>
+            </div>
           )}
-        </div>
+        </motion.div>
       </main>
     </div>
   );

--- a/src/features/formulas/bmr/Katch/components/KatchMcArdleForm/KatchMcArdleForm.tsx
+++ b/src/features/formulas/bmr/Katch/components/KatchMcArdleForm/KatchMcArdleForm.tsx
@@ -7,10 +7,11 @@ import InputField from "@/components/ui/Input/InputField";
 import SelectField from "@/components/ui/Select/SelectField";
 
 type KatchMcArdleFormProps = {
-  setBmr: (bmr: number) => void;
+  onCalculate: (bmr: number, values: KatchMcArdleInput) => void;
+  onClear: () => void;
 };
 
-const KatchMcArdleForm = ({ setBmr }: KatchMcArdleFormProps) => {
+const KatchMcArdleForm = ({ onCalculate, onClear }: KatchMcArdleFormProps) => {
   const form = useForm({
     defaultValues: {
       leanBodyMass: 65,
@@ -18,7 +19,7 @@ const KatchMcArdleForm = ({ setBmr }: KatchMcArdleFormProps) => {
     } satisfies KatchMcArdleInput,
     onSubmit: async ({ value }) => {
       const bmr = calculateKatchMcArdle(value);
-      setBmr(bmr);
+      onCalculate(bmr, value);
     },
   });
   const unit = useStore(form.store, (state) => state.values.unit);
@@ -67,7 +68,7 @@ const KatchMcArdleForm = ({ setBmr }: KatchMcArdleFormProps) => {
         onClick={(e) => {
           e.preventDefault();
           form.reset();
-          setBmr(0);
+          onClear();
         }}
         className={clsx(styles.btnOutline)}
       >

--- a/src/features/formulas/bmr/Katch/components/UserValues/UserValues.module.scss
+++ b/src/features/formulas/bmr/Katch/components/UserValues/UserValues.module.scss
@@ -1,0 +1,12 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/formulas/bmr/Katch/components/UserValues/UserValues.tsx
+++ b/src/features/formulas/bmr/Katch/components/UserValues/UserValues.tsx
@@ -1,0 +1,20 @@
+import styles from "./UserValues.module.scss";
+import type { KatchMcArdleInput } from "@/utils/coreFunctions/bmr/types";
+
+type UserValuesProps = {
+  values: KatchMcArdleInput;
+};
+
+const UserValues = ({ values }: UserValuesProps) => {
+  return (
+    <div className={styles.summary}>
+      <div className={styles.row}>
+        <span>
+          <strong>Lean Body Mass:</strong> {values.leanBodyMass} {values.unit === "metric" ? "kg" : "lbs"}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default UserValues;

--- a/src/features/formulas/bodyComposition/BodyCompositionPage.module.scss
+++ b/src/features/formulas/bodyComposition/BodyCompositionPage.module.scss
@@ -9,19 +9,51 @@
 
 .main {
   flex: 1;
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
 }
 
 .heading {
   @include heading;
 }
 
-.formContainer {
+.btnOutline {
+  @include btnOutline;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  min-height: 420px;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.face {
+  position: absolute;
+  width: 100%;
+  backface-visibility: hidden;
+  top: 0;
+  left: 0;
+  background: var(--color-background);
+  border-radius: 1rem;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.back {
+  transform: rotateY(180deg);
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: start;
-  gap: 4rem;
-  .form {
-  }
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-background);
+  padding: 2rem;
+  border-radius: 1rem;
+  z-index: 1;
+}
+
+.front {
+  z-index: 2;
 }

--- a/src/features/formulas/bodyComposition/BodyCompositionPage.tsx
+++ b/src/features/formulas/bodyComposition/BodyCompositionPage.tsx
@@ -1,11 +1,13 @@
 import Navbar from "@/components/layout/Navbar/Navbar";
 import BodyCompositionForm from "./components/BodyCompositionForm/BodyCompositionForm";
+import UserValues from "./components/UserValues/UserValues";
 import clsx from "clsx";
 import styles from "./BodyCompositionPage.module.scss";
 import { useTheme } from "@/components/providers/ThemeProvider/ThemeProvider";
 import CalculatorResults from "../components/CalculatorResults/CalculatorResults";
 import { useState } from "react";
-import Card from "@/components/ui/Card/Card";
+import { motion } from "framer-motion";
+import type { BodyFatInput } from "@/utils/coreFunctions/body-composition/types";
 import { truncateTo2Digits } from "@/utils/helpers/helperFunctions";
 
 const BodyCompositionPage = () => {
@@ -14,16 +16,9 @@ const BodyCompositionPage = () => {
   const [bodyFat, setBodyFat] = useState<number | null>(null);
   const [leanMass, setLeanMass] = useState<number | null>(null);
   const [fatMass, setFatMass] = useState<number | null>(null);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [formValues, setFormValues] = useState<(BodyFatInput & { weight: number }) | null>(null);
 
-  const handleEstimate = (
-    bodyFat: number,
-    leanMass: number,
-    fatMass: number
-  ) => {
-    setBodyFat(bodyFat);
-    setLeanMass(leanMass);
-    setFatMass(fatMass);
-  };
 
   return (
     <div className={clsx(styles.page)}>
@@ -32,34 +27,63 @@ const BodyCompositionPage = () => {
         <h1 className={clsx(styles.heading, theme === "dark" && styles.dark)}>
           Body Composition Calculator
         </h1>
-        <div className={styles.formContainer}>
-          <Card className={styles.form}>
-            <BodyCompositionForm onEstimate={handleEstimate} />
-          </Card>
-          <div className={styles.results}>
-            {bodyFat !== null && bodyFat !== 0 && (
-              <CalculatorResults
-                result={truncateTo2Digits(bodyFat).toString()}
-                label="Body Fat %"
-                unit="%"
-              />
-            )}
-            {leanMass !== null && leanMass !== 0 && (
-              <CalculatorResults
-                result={truncateTo2Digits(leanMass).toString()}
-                label="Lean Body Mass"
-                unit="kg"
-              />
-            )}
-            {fatMass !== null && fatMass !== 0 && (
-              <CalculatorResults
-                result={truncateTo2Digits(fatMass).toString()}
-                label="Fat Mass"
-                unit="kg"
-              />
-            )}
+        <motion.div
+          className={clsx(styles.card)}
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className={clsx(styles.face, styles.front)}>
+            <BodyCompositionForm
+              onCalculate={(bf, lm, fm, values) => {
+                setBodyFat(bf);
+                setLeanMass(lm);
+                setFatMass(fm);
+                setFormValues(values);
+                setIsFlipped(true);
+              }}
+              onClear={() => {
+                setBodyFat(null);
+                setLeanMass(null);
+                setFatMass(null);
+                setFormValues(null);
+                setIsFlipped(false);
+              }}
+            />
           </div>
-        </div>
+
+          {formValues && (
+            <div className={clsx(styles.face, styles.back)}>
+              <UserValues values={formValues} />
+              {bodyFat !== null && bodyFat !== 0 && (
+                <CalculatorResults
+                  result={truncateTo2Digits(bodyFat).toString()}
+                  label="Body Fat %"
+                  unit="%"
+                />
+              )}
+              {leanMass !== null && leanMass !== 0 && (
+                <CalculatorResults
+                  result={truncateTo2Digits(leanMass).toString()}
+                  label="Lean Body Mass"
+                  unit="kg"
+                />
+              )}
+              {fatMass !== null && fatMass !== 0 && (
+                <CalculatorResults
+                  result={truncateTo2Digits(fatMass).toString()}
+                  label="Fat Mass"
+                  unit="kg"
+                />
+              )}
+              <button
+                onClick={() => setIsFlipped(false)}
+                className={clsx(styles.btnOutline)}
+              >
+                Go Back
+              </button>
+            </div>
+          )}
+        </motion.div>
       </main>
     </div>
   );

--- a/src/features/formulas/bodyComposition/components/BodyCompositionForm/BodyCompositionForm.tsx
+++ b/src/features/formulas/bodyComposition/components/BodyCompositionForm/BodyCompositionForm.tsx
@@ -11,10 +11,16 @@ import InputField from "@/components/ui/Input/InputField";
 import SelectField from "@/components/ui/Select/SelectField";
 
 type BodyCompositionFormProps = {
-  onEstimate: (bodyFat: number, leanMass: number, fatMass: number) => void;
+  onCalculate: (
+    bodyFat: number,
+    leanMass: number,
+    fatMass: number,
+    values: BodyFatInput & { weight: number }
+  ) => void;
+  onClear: () => void;
 };
 
-const BodyCompositionForm = ({ onEstimate }: BodyCompositionFormProps) => {
+const BodyCompositionForm = ({ onCalculate, onClear }: BodyCompositionFormProps) => {
   const form = useForm({
     defaultValues: {
       sex: "male" as BodyFatInput["sex"],
@@ -37,7 +43,7 @@ const BodyCompositionForm = ({ onEstimate }: BodyCompositionFormProps) => {
         bodyFatPercent: bodyFat,
         unit: value.unit,
       });
-      onEstimate(bodyFat, leanMass, fatMass);
+      onCalculate(bodyFat, leanMass, fatMass, value);
     },
   });
   const unit = useStore(form.store, (state) => state.values.unit);
@@ -162,7 +168,7 @@ const BodyCompositionForm = ({ onEstimate }: BodyCompositionFormProps) => {
         onClick={(e) => {
           e.preventDefault();
           form.reset();
-          onEstimate(0, 0, 0);
+          onClear();
         }}
         className={clsx(styles.btnOutline)}
       >

--- a/src/features/formulas/bodyComposition/components/UserValues/UserValues.module.scss
+++ b/src/features/formulas/bodyComposition/components/UserValues/UserValues.module.scss
@@ -1,0 +1,12 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/formulas/bodyComposition/components/UserValues/UserValues.tsx
+++ b/src/features/formulas/bodyComposition/components/UserValues/UserValues.tsx
@@ -1,0 +1,46 @@
+import styles from "./UserValues.module.scss";
+import type { BodyFatInput } from "@/utils/coreFunctions/body-composition/types";
+
+type BodyCompositionInput = BodyFatInput & { weight: number };
+
+type UserValuesProps = {
+  values: BodyCompositionInput;
+};
+
+const UserValues = ({ values }: UserValuesProps) => {
+  const unit = values.unit === "metric" ? { wt: "kg", len: "cm" } : { wt: "lbs", len: "in" };
+  return (
+    <div className={styles.summary}>
+      <div className={styles.row}>
+        <span>
+          <strong>Weight:</strong> {values.weight} {unit.wt}
+        </span>
+        <span>
+          <strong>Height:</strong> {values.height} {unit.len}
+        </span>
+      </div>
+      <div className={styles.row}>
+        <span>
+          <strong>Waist:</strong> {values.waist} {unit.len}
+        </span>
+        <span>
+          <strong>Neck:</strong> {values.neck} {unit.len}
+        </span>
+      </div>
+      {values.sex === "female" && (
+        <div className={styles.row}>
+          <span>
+            <strong>Hip:</strong> {values.hip} {unit.len}
+          </span>
+        </div>
+      )}
+      <div className={styles.row}>
+        <span>
+          <strong>Sex:</strong> {values.sex}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default UserValues;

--- a/src/features/formulas/macros/MacrosPage.module.scss
+++ b/src/features/formulas/macros/MacrosPage.module.scss
@@ -9,19 +9,53 @@
 
 .main {
   flex: 1;
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
 }
 
 .heading {
   @include heading;
 }
 
-.form {
+.btnOutline {
+  @include btnOutline;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  min-height: 420px;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.face {
+  position: absolute;
+  width: 100%;
+  backface-visibility: hidden;
+  top: 0;
+  left: 0;
+  background: var(--color-background);
+  border-radius: 1rem;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.back {
+  transform: rotateY(180deg);
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: start;
-  gap: 4rem;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-background);
+  padding: 2rem;
+  border-radius: 1rem;
+  z-index: 1;
+}
+
+.front {
+  z-index: 2;
 }
 
 .results {

--- a/src/features/formulas/macros/MacrosPage.tsx
+++ b/src/features/formulas/macros/MacrosPage.tsx
@@ -1,11 +1,13 @@
 import Navbar from "@/components/layout/Navbar/Navbar";
 import MacrosForm from "./components/MacrosForm/MacrosForm";
+import UserValues from "./components/UserValues/UserValues";
 import clsx from "clsx";
 import styles from "./MacrosPage.module.scss";
 import { useTheme } from "@/components/providers/ThemeProvider/ThemeProvider";
 import CalculatorResults from "../components/CalculatorResults/CalculatorResults";
 import { useState } from "react";
-import Card from "@/components/ui/Card/Card";
+import { motion } from "framer-motion";
+import type { MacroInput } from "@/utils/coreFunctions/macros/types";
 
 export type MacroResults = {
   protein: number;
@@ -16,6 +18,8 @@ export type MacroResults = {
 const MacrosPage = () => {
   const { theme } = useTheme();
   const [macros, setMacros] = useState<MacroResults | null>(null);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [formValues, setFormValues] = useState<MacroInput | null>(null);
 
   return (
     <div className={clsx(styles.page)}>
@@ -24,33 +28,43 @@ const MacrosPage = () => {
         <h1 className={clsx(styles.heading, theme === "dark" && styles.dark)}>
           Macronutrient Calculator
         </h1>
-        <div className={styles.form}>
-          <Card>
-            <MacrosForm setMacros={setMacros} />
-          </Card>
-          {macros &&
-            macros.protein !== 0 &&
-            macros.fats !== 0 &&
-            macros.carbs !== 0 && (
+        <motion.div
+          className={clsx(styles.card)}
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className={clsx(styles.face, styles.front)}>
+            <MacrosForm
+              onCalculate={(res, values) => {
+                setMacros(res);
+                setFormValues(values);
+                setIsFlipped(true);
+              }}
+              onClear={() => {
+                setMacros(null);
+                setFormValues(null);
+                setIsFlipped(false);
+              }}
+            />
+          </div>
+
+          {macros && formValues && (
+            <div className={clsx(styles.face, styles.back)}>
+              <UserValues values={formValues} />
               <div className={styles.results}>
-                <CalculatorResults
-                  result={macros.protein.toString()}
-                  label="Protein"
-                  unit="g"
-                />
-                <CalculatorResults
-                  result={macros.fats.toString()}
-                  label="Fats"
-                  unit="g"
-                />
-                <CalculatorResults
-                  result={macros.carbs.toString()}
-                  label="Carbs"
-                  unit="g"
-                />
+                <CalculatorResults result={macros.protein.toString()} label="Protein" unit="g" />
+                <CalculatorResults result={macros.fats.toString()} label="Fats" unit="g" />
+                <CalculatorResults result={macros.carbs.toString()} label="Carbs" unit="g" />
               </div>
-            )}
-        </div>
+              <button
+                onClick={() => setIsFlipped(false)}
+                className={clsx(styles.btnOutline)}
+              >
+                Go Back
+              </button>
+            </div>
+          )}
+        </motion.div>
       </main>
     </div>
   );

--- a/src/features/formulas/macros/components/MacrosForm/MacrosForm.tsx
+++ b/src/features/formulas/macros/components/MacrosForm/MacrosForm.tsx
@@ -8,10 +8,11 @@ import SelectField from "@/components/ui/Select/SelectField";
 import type { MacroResults } from "../../MacrosPage";
 
 type MacrosFormProps = {
-  setMacros: (macros: MacroResults) => void;
+  onCalculate: (macros: MacroResults, values: MacroInput) => void;
+  onClear: () => void;
 };
 
-const MacrosForm = ({ setMacros }: MacrosFormProps) => {
+const MacrosForm = ({ onCalculate, onClear }: MacrosFormProps) => {
   const form = useForm({
     defaultValues: {
       weight: 80,
@@ -22,7 +23,7 @@ const MacrosForm = ({ setMacros }: MacrosFormProps) => {
     } satisfies MacroInput,
     onSubmit: async ({ value }) => {
       const macros = calculateMacros(value);
-      setMacros(macros);
+      onCalculate(macros, value);
     },
   });
 
@@ -107,11 +108,7 @@ const MacrosForm = ({ setMacros }: MacrosFormProps) => {
         onClick={(e) => {
           e.preventDefault();
           form.reset();
-          setMacros({
-            protein: 0,
-            carbs: 0,
-            fats: 0,
-          });
+          onClear();
         }}
         className={clsx(styles.btnOutline)}
       >

--- a/src/features/formulas/macros/components/UserValues/UserValues.module.scss
+++ b/src/features/formulas/macros/components/UserValues/UserValues.module.scss
@@ -1,0 +1,12 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/formulas/macros/components/UserValues/UserValues.tsx
+++ b/src/features/formulas/macros/components/UserValues/UserValues.tsx
@@ -1,0 +1,32 @@
+import styles from "./UserValues.module.scss";
+import type { MacroInput } from "@/utils/coreFunctions/macros/types";
+
+type UserValuesProps = {
+  values: MacroInput;
+};
+
+const UserValues = ({ values }: UserValuesProps) => {
+  const weightUnit = values.unit === "metric" ? "kg" : "lbs";
+  return (
+    <div className={styles.summary}>
+      <div className={styles.row}>
+        <span>
+          <strong>Weight:</strong> {values.weight} {weightUnit}
+        </span>
+        <span>
+          <strong>Calories:</strong> {values.totalCalories} kcal
+        </span>
+      </div>
+      <div className={styles.row}>
+        <span>
+          <strong>Protein/kg:</strong> {values.proteinPerKg}
+        </span>
+        <span>
+          <strong>Fat %:</strong> {values.fatPercent}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default UserValues;

--- a/src/features/formulas/tdee/TDEEPage.module.scss
+++ b/src/features/formulas/tdee/TDEEPage.module.scss
@@ -9,17 +9,51 @@
 
 .main {
   flex: 1;
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
 }
 
 .heading {
   @include heading;
 }
 
-.form {
+.btnOutline {
+  @include btnOutline;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  min-height: 420px;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.face {
+  position: absolute;
+  width: 100%;
+  backface-visibility: hidden;
+  top: 0;
+  left: 0;
+  background: var(--color-background);
+  border-radius: 1rem;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.back {
+  transform: rotateY(180deg);
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: start;
-  gap: 4rem;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-background);
+  padding: 2rem;
+  border-radius: 1rem;
+  z-index: 1;
+}
+
+.front {
+  z-index: 2;
 }

--- a/src/features/formulas/tdee/TDEEPage.tsx
+++ b/src/features/formulas/tdee/TDEEPage.tsx
@@ -1,15 +1,19 @@
 import Navbar from "@/components/layout/Navbar/Navbar";
 import TDEEForm from "./components/TDEEForm/TDEEForm";
+import UserValues from "./components/UserValues/UserValues";
 import clsx from "clsx";
 import styles from "./TDEEPage.module.scss";
 import { useTheme } from "@/components/providers/ThemeProvider/ThemeProvider";
 import CalculatorResults from "../components/CalculatorResults/CalculatorResults";
 import { useState } from "react";
-import Card from "@/components/ui/Card/Card";
+import { motion } from "framer-motion";
+import type { TDEEInput } from "@/utils/coreFunctions/tdee/types";
 
 const TDEEPage = () => {
   const { theme } = useTheme();
   const [tdee, setTdee] = useState<number>(0);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [formValues, setFormValues] = useState<TDEEInput | null>(null);
 
   return (
     <div className={clsx(styles.page)}>
@@ -18,18 +22,40 @@ const TDEEPage = () => {
         <h1 className={clsx(styles.heading, theme === "dark" && styles.dark)}>
           Total Daily Energy Expenditure
         </h1>
-        <div className={styles.form}>
-          <Card>
-            <TDEEForm setTdee={setTdee} />
-          </Card>
-          {tdee !== 0 && (
-            <CalculatorResults
-              result={tdee.toString()}
-              label="TDEE"
-              unit="kcal"
+
+        <motion.div
+          className={clsx(styles.card)}
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className={clsx(styles.face, styles.front)}>
+            <TDEEForm
+              onCalculate={(val, values) => {
+                setFormValues(values);
+                setTdee(val);
+                setIsFlipped(true);
+              }}
+              onClear={() => {
+                setTdee(0);
+                setFormValues(null);
+                setIsFlipped(false);
+              }}
             />
+          </div>
+
+          {formValues && (
+            <div className={clsx(styles.face, styles.back)}>
+              <UserValues values={formValues} />
+              <CalculatorResults result={tdee.toString()} label="TDEE" unit="kcal" />
+              <button
+                onClick={() => setIsFlipped(false)}
+                className={clsx(styles.btnOutline)}
+              >
+                Go Back
+              </button>
+            </div>
           )}
-        </div>
+        </motion.div>
       </main>
     </div>
   );

--- a/src/features/formulas/tdee/components/TDEEForm/TDEEForm.tsx
+++ b/src/features/formulas/tdee/components/TDEEForm/TDEEForm.tsx
@@ -7,10 +7,11 @@ import InputField from "@/components/ui/Input/InputField";
 import SelectField from "@/components/ui/Select/SelectField";
 
 type TDEEFormProps = {
-  setTdee: (tdee: number) => void;
+  onCalculate: (tdee: number, values: TDEEInput) => void;
+  onClear: () => void;
 };
 
-const TDEEForm = ({ setTdee }: TDEEFormProps) => {
+const TDEEForm = ({ onCalculate, onClear }: TDEEFormProps) => {
   const form = useForm({
     defaultValues: {
       bmr: 1800,
@@ -18,7 +19,7 @@ const TDEEForm = ({ setTdee }: TDEEFormProps) => {
     } satisfies TDEEInput,
     onSubmit: async ({ value }) => {
       const tdee = calculateTDEE(value);
-      setTdee(tdee);
+      onCalculate(tdee, value);
     },
   });
 
@@ -69,7 +70,7 @@ const TDEEForm = ({ setTdee }: TDEEFormProps) => {
         onClick={(e) => {
           e.preventDefault();
           form.reset();
-          setTdee(0);
+          onClear();
         }}
         className={clsx(styles.btnOutline)}
       >

--- a/src/features/formulas/tdee/components/UserValues/UserValues.module.scss
+++ b/src/features/formulas/tdee/components/UserValues/UserValues.module.scss
@@ -1,0 +1,12 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/formulas/tdee/components/UserValues/UserValues.tsx
+++ b/src/features/formulas/tdee/components/UserValues/UserValues.tsx
@@ -1,0 +1,23 @@
+import styles from "./UserValues.module.scss";
+import type { TDEEInput } from "@/utils/coreFunctions/tdee/types";
+
+type UserValuesProps = {
+  values: TDEEInput;
+};
+
+const UserValues = ({ values }: UserValuesProps) => {
+  return (
+    <div className={styles.summary}>
+      <div className={styles.row}>
+        <span>
+          <strong>BMR:</strong> {values.bmr} kcal
+        </span>
+        <span>
+          <strong>Activity:</strong> {values.activityLevel}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default UserValues;


### PR DESCRIPTION
## Summary
- implement flip-card style for Katch, TDEE, Body Composition and Macros calculators
- show entered values on result screen for each calculator
- refactor forms to return entered values and support clearing
- style pages with card flip animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_684efab97cd083269e2b224882bf616e