### PR TITLE
Add Harris-Benedict BMR formula

### DIFF
--- a/src/features/formulas/bmr/Harris/HarrisBenedictPage.module.scss
+++ b/src/features/formulas/bmr/Harris/HarrisBenedictPage.module.scss
@@ -1,0 +1,74 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-background);
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+}
+
+.heading {
+  @include heading;
+}
+
+.content {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 4rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.result {
+  position: absolute;
+  z-index: 0;
+}
+
+.btnOutline {
+  @include btnOutline;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  min-height: 420px;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.face {
+  position: absolute;
+  width: 100%;
+  backface-visibility: hidden;
+  top: 0;
+  left: 0;
+  background: var(--color-background);
+  border-radius: 1rem;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.back {
+  transform: rotateY(180deg);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-background);
+  padding: 2rem;
+  border-radius: 1rem;
+  z-index: 1;
+}
+
+.front {
+  z-index: 2;
+}

--- a/src/features/formulas/bmr/Harris/HarrisBenedictPage.tsx
+++ b/src/features/formulas/bmr/Harris/HarrisBenedictPage.tsx
@@ -1,0 +1,61 @@
+import HarrisBenedictForm from "./components/HarrisBenedictForm/HarrisBenedictForm";
+import clsx from "clsx";
+import styles from "./HarrisBenedictPage.module.scss";
+import CalculatorResults from "../../components/CalculatorResults/CalculatorResults";
+import { useState } from "react";
+import { motion } from "framer-motion";
+import type { HarrisBenedictInput } from "@/utils/coreFunctions/bmr/types";
+import UserValues from "./components/UserValues/UserValues";
+import CalculatorLayout from "@/components/layout/PageLayouts/CalculatorLayout/CalculatorLayout";
+
+const HarrisBenedictPage = () => {
+  const [bmr, setBmr] = useState<number>(0);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [formValues, setFormValues] = useState<HarrisBenedictInput | null>(null);
+
+  return (
+    <CalculatorLayout title="Harris-Benedict BMR Calculator">
+      <motion.div
+        className={clsx(styles.card)}
+        animate={{ rotateY: isFlipped ? 180 : 0 }}
+        transition={{ duration: 0.6 }}
+      >
+        {/* Front Face: Form */}
+        <div className={clsx(styles.face, styles.front)}>
+          <HarrisBenedictForm
+            onCalculate={(bmr, values) => {
+              setFormValues(values);
+              setBmr(bmr);
+              setIsFlipped(true);
+            }}
+            onClear={() => {
+              setBmr(0);
+              setFormValues(null);
+              setIsFlipped(false); // unflip
+            }}
+          />
+        </div>
+
+        {/* Back Face: Result + Entered Values */}
+        {formValues && (
+          <div className={clsx(styles.face, styles.back)}>
+            <UserValues values={formValues} />
+            <CalculatorResults
+              result={bmr.toString()}
+              label="BMR"
+              unit="kcal"
+            />
+            <button
+              onClick={() => setIsFlipped(false)}
+              className={clsx(styles.btnOutline)}
+            >
+              Go Back
+            </button>
+          </div>
+        )}
+      </motion.div>
+    </CalculatorLayout>
+  );
+};
+
+export default HarrisBenedictPage;

--- a/src/features/formulas/bmr/Harris/components/HarrisBenedictForm/HarrisBenedictForm.module.scss
+++ b/src/features/formulas/bmr/Harris/components/HarrisBenedictForm/HarrisBenedictForm.module.scss
@@ -1,0 +1,29 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+.container {
+  width: 100%;
+  max-width: 500px;
+  flex-shrink: 0;
+  z-index: 1;
+}
+.form {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  min-width: 300px;
+  max-width: 500px;
+  gap: 1rem;
+}
+
+.input,
+.select {
+  @include input;
+  width: 100%;
+}
+
+.btnPrimary {
+  @include btnPrimary;
+}
+.btnOutline {
+  @include btnOutline;
+}

--- a/src/features/formulas/bmr/Harris/components/HarrisBenedictForm/HarrisBenedictForm.tsx
+++ b/src/features/formulas/bmr/Harris/components/HarrisBenedictForm/HarrisBenedictForm.tsx
@@ -1,0 +1,134 @@
+import { calculateHarrisBenedict } from "@/utils/coreFunctions/bmr";
+import { HarrisBenedictInput } from "@/utils/coreFunctions/bmr/types";
+import { useForm } from "@tanstack/react-form";
+import clsx from "clsx";
+import styles from "./HarrisBenedictForm.module.scss";
+import InputField from "@/components/ui/Input/InputField";
+import SelectField from "@/components/ui/Select/SelectField";
+import { useStore } from "@tanstack/react-form";
+import Card from "@/components/ui/Card/Card";
+
+type HarrisBenedictFormProps = {
+  onCalculate: (bmr: number, values: HarrisBenedictInput) => void;
+  onClear: () => void;
+};
+
+const HarrisBenedictForm = ({
+  onCalculate,
+  onClear,
+}: HarrisBenedictFormProps) => {
+  const form = useForm({
+    defaultValues: {
+      weight: 0,
+      height: 0,
+      age: 0,
+      sex: "" as HarrisBenedictInput["sex"],
+      unit: "" as HarrisBenedictInput["unit"],
+    } satisfies HarrisBenedictInput,
+    onSubmit: async ({ value }) => {
+      const bmr = calculateHarrisBenedict(value);
+      onCalculate(bmr, value);
+    },
+  });
+
+  const unit = useStore(form.store, (state) => state.values.unit);
+  const weightUnit = unit === "metric" ? "kg" : "lbs";
+  const heightUnit = unit === "metric" ? "cm" : "in";
+
+  const onClearForm = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    form.reset();
+    onClear();
+  };
+
+  return (
+    <Card className={styles.container}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void form.handleSubmit();
+        }}
+        className={styles.form}
+      >
+        <form.Field name="weight">
+          {(field) => (
+            <InputField
+              type="number"
+              label="Weight"
+              placeholder="Enter weight"
+              value={field.state.value}
+              unit={weightUnit}
+              onChange={(val) => field.handleChange(Number(val))}
+            />
+          )}
+        </form.Field>
+
+        <form.Field name="height">
+          {(field) => (
+            <InputField
+              type="number"
+              label="Height"
+              placeholder="Enter height"
+              value={field.state.value}
+              unit={heightUnit}
+              onChange={(val) => field.handleChange(Number(val))}
+            />
+          )}
+        </form.Field>
+
+        <form.Field name="age">
+          {(field) => (
+            <InputField
+              type="number"
+              label="Age"
+              placeholder="Enter age"
+              value={field.state.value}
+              onChange={(val) => field.handleChange(Number(val))}
+            />
+          )}
+        </form.Field>
+
+        <form.Field name="sex">
+          {(field) => (
+            <SelectField
+              label="Sex"
+              value={field.state.value}
+              onChange={(val) =>
+                field.handleChange(val as HarrisBenedictInput["sex"])
+              }
+              options={[
+                { value: "male", label: "Male" },
+                { value: "female", label: "Female" },
+              ]}
+            />
+          )}
+        </form.Field>
+
+        <form.Field name="unit">
+          {(field) => (
+            <SelectField
+              label="Unit"
+              value={field.state.value || "metric"}
+              onChange={(val) =>
+                field.handleChange(val as HarrisBenedictInput["unit"])
+              }
+              options={[
+                { value: "metric", label: "Metric (kg, cm)" },
+                { value: "imperial", label: "Imperial (lbs, inches)" },
+              ]}
+            />
+          )}
+        </form.Field>
+
+        <button type="submit" className={clsx(styles.btnPrimary)}>
+          Calculate BMR
+        </button>
+        <button onClick={onClearForm} className={clsx(styles.btnOutline)}>
+          Clear
+        </button>
+      </form>
+    </Card>
+  );
+};
+
+export default HarrisBenedictForm;

--- a/src/features/formulas/bmr/Harris/components/UserValues/UserValues.module.scss
+++ b/src/features/formulas/bmr/Harris/components/UserValues/UserValues.module.scss
@@ -1,0 +1,12 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/formulas/bmr/Harris/components/UserValues/UserValues.tsx
+++ b/src/features/formulas/bmr/Harris/components/UserValues/UserValues.tsx
@@ -1,0 +1,34 @@
+import styles from "./UserValues.module.scss";
+
+import type { HarrisBenedictInput } from "@/utils/coreFunctions/bmr/types";
+
+type UserValuesProps = {
+  values: HarrisBenedictInput;
+};
+
+const UserValues = ({ values }: UserValuesProps) => {
+  return (
+    <div className={styles.summary}>
+      <div className={styles.row}>
+        <span>
+          <strong>Weight:</strong> {values.weight}{" "}
+          {values.unit === "metric" ? "kg" : "lbs"}
+        </span>
+        <span>
+          <strong>Height:</strong> {values.height}{" "}
+          {values.unit === "metric" ? "cm" : "in"}
+        </span>
+      </div>
+      <div className={styles.row}>
+        <span>
+          <strong>Age:</strong> {values.age}
+        </span>
+        <span>
+          <strong>Sex:</strong> {values.sex}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default UserValues;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -31,6 +31,9 @@ const DashboardbmrMifflinBmrMifflinLazyImport = createFileRoute(
 const DashboardbmrKatchBmrKatchLazyImport = createFileRoute(
   '/dashboard/(bmr-katch)/bmr-katch',
 )()
+const DashboardbmrHarrisBmrHarrisLazyImport = createFileRoute(
+  '/dashboard/(bmr-harris)/bmr-harris',
+)()
 
 // Create/Update Routes
 
@@ -95,6 +98,17 @@ const DashboardbmrKatchBmrKatchLazyRoute =
     ),
   )
 
+const DashboardbmrHarrisBmrHarrisLazyRoute =
+  DashboardbmrHarrisBmrHarrisLazyImport.update({
+    id: '/dashboard/(bmr-harris)/bmr-harris',
+    path: '/dashboard/bmr-harris',
+    getParentRoute: () => rootRoute,
+  } as any).lazy(() =>
+    import('./routes/dashboard/(bmr-harris)/bmr-harris.lazy').then(
+      (d) => d.Route,
+    ),
+  )
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -118,6 +132,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard/bmr-katch'
       fullPath: '/dashboard/bmr-katch'
       preLoaderRoute: typeof DashboardbmrKatchBmrKatchLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/dashboard/(bmr-harris)/bmr-harris': {
+      id: '/dashboard/(bmr-harris)/bmr-harris'
+      path: '/dashboard/bmr-harris'
+      fullPath: '/dashboard/bmr-harris'
+      preLoaderRoute: typeof DashboardbmrHarrisBmrHarrisLazyImport
       parentRoute: typeof rootRoute
     }
     '/dashboard/(bmr-mifflin)/bmr-mifflin': {
@@ -157,6 +178,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardIndexRoute
   '/dashboard/bmr-katch': typeof DashboardbmrKatchBmrKatchLazyRoute
+  '/dashboard/bmr-harris': typeof DashboardbmrHarrisBmrHarrisLazyRoute
   '/dashboard/bmr-mifflin': typeof DashboardbmrMifflinBmrMifflinLazyRoute
   '/dashboard/body-composition': typeof DashboardbodyCompositionBodyCompositionLazyRoute
   '/dashboard/macros': typeof DashboardmacrosMacrosLazyRoute
@@ -167,6 +189,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardIndexRoute
   '/dashboard/bmr-katch': typeof DashboardbmrKatchBmrKatchLazyRoute
+  '/dashboard/bmr-harris': typeof DashboardbmrHarrisBmrHarrisLazyRoute
   '/dashboard/bmr-mifflin': typeof DashboardbmrMifflinBmrMifflinLazyRoute
   '/dashboard/body-composition': typeof DashboardbodyCompositionBodyCompositionLazyRoute
   '/dashboard/macros': typeof DashboardmacrosMacrosLazyRoute
@@ -190,6 +213,7 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/dashboard/bmr-katch'
+    | '/dashboard/bmr-harris'
     | '/dashboard/bmr-mifflin'
     | '/dashboard/body-composition'
     | '/dashboard/macros'
@@ -199,6 +223,7 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/dashboard/bmr-katch'
+    | '/dashboard/bmr-harris'
     | '/dashboard/bmr-mifflin'
     | '/dashboard/body-composition'
     | '/dashboard/macros'
@@ -208,6 +233,7 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard/'
     | '/dashboard/(bmr-katch)/bmr-katch'
+    | '/dashboard/(bmr-harris)/bmr-harris'
     | '/dashboard/(bmr-mifflin)/bmr-mifflin'
     | '/dashboard/(body-composition)/body-composition'
     | '/dashboard/(macros)/macros'
@@ -219,6 +245,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DashboardIndexRoute: typeof DashboardIndexRoute
   DashboardbmrKatchBmrKatchLazyRoute: typeof DashboardbmrKatchBmrKatchLazyRoute
+  DashboardbmrHarrisBmrHarrisLazyRoute: typeof DashboardbmrHarrisBmrHarrisLazyRoute
   DashboardbmrMifflinBmrMifflinLazyRoute: typeof DashboardbmrMifflinBmrMifflinLazyRoute
   DashboardbodyCompositionBodyCompositionLazyRoute: typeof DashboardbodyCompositionBodyCompositionLazyRoute
   DashboardmacrosMacrosLazyRoute: typeof DashboardmacrosMacrosLazyRoute
@@ -229,6 +256,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardIndexRoute: DashboardIndexRoute,
   DashboardbmrKatchBmrKatchLazyRoute: DashboardbmrKatchBmrKatchLazyRoute,
+  DashboardbmrHarrisBmrHarrisLazyRoute: DashboardbmrHarrisBmrHarrisLazyRoute,
   DashboardbmrMifflinBmrMifflinLazyRoute:
     DashboardbmrMifflinBmrMifflinLazyRoute,
   DashboardbodyCompositionBodyCompositionLazyRoute:
@@ -250,6 +278,7 @@ export const routeTree = rootRoute
         "/",
         "/dashboard/",
         "/dashboard/(bmr-katch)/bmr-katch",
+        "/dashboard/(bmr-harris)/bmr-harris",
         "/dashboard/(bmr-mifflin)/bmr-mifflin",
         "/dashboard/(body-composition)/body-composition",
         "/dashboard/(macros)/macros",
@@ -264,6 +293,9 @@ export const routeTree = rootRoute
     },
     "/dashboard/(bmr-katch)/bmr-katch": {
       "filePath": "dashboard/(bmr-katch)/bmr-katch.lazy.tsx"
+    },
+    "/dashboard/(bmr-harris)/bmr-harris": {
+      "filePath": "dashboard/(bmr-harris)/bmr-harris.lazy.tsx"
     },
     "/dashboard/(bmr-mifflin)/bmr-mifflin": {
       "filePath": "dashboard/(bmr-mifflin)/bmr-mifflin.lazy.tsx"

--- a/src/routes/dashboard/(bmr-harris)/bmr-harris.lazy.tsx
+++ b/src/routes/dashboard/(bmr-harris)/bmr-harris.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import HarrisBenedictPage from "../../../features/formulas/bmr/Harris/HarrisBenedictPage";
+
+export const Route = createLazyFileRoute("/dashboard/(bmr-harris)/bmr-harris")({
+  component: HarrisBenedictPage,
+});

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -17,6 +17,9 @@ function Dashboard() {
           <Link to="/dashboard/bmr-katch" className={styles.link}>
             <div className={styles.btn}>Katch-McArdle (BMR)</div>
           </Link>
+          <Link to="/dashboard/bmr-harris" className={styles.link}>
+            <div className={styles.btn}>Harris-Benedict (BMR)</div>
+          </Link>
           <Link to="/dashboard/tdee" className={styles.link}>
             <div className={styles.btn}>Total daily energy expenditure</div>
           </Link>

--- a/src/utils/coreFunctions/__tests__/core.test.ts
+++ b/src/utils/coreFunctions/__tests__/core.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   calculateMifflinStJeor,
   calculateKatchMcArdle,
+  calculateHarrisBenedict,
   calculateTDEE,
   calculateMacros,
   estimateBodyFatPercentage,
@@ -39,6 +40,17 @@ describe("BMR Calculations", () => {
       unit: "metric",
     });
     expect(Math.round(bmr)).toBeCloseTo(1774, -1);
+  });
+
+  it("calculates Harris-Benedict", () => {
+    const bmr = calculateHarrisBenedict({
+      weight: 80,
+      height: 180,
+      age: 30,
+      sex: "male",
+      unit: "metric",
+    });
+    expect(Math.round(bmr)).toBe(1854);
   });
 });
 

--- a/src/utils/coreFunctions/index.ts
+++ b/src/utils/coreFunctions/index.ts
@@ -1,6 +1,14 @@
 // BMR formulas
-export { calculateMifflinStJeor, calculateKatchMcArdle } from "./bmr/index";
-export type { MifflinStJeorInput, KatchMcArdleInput } from "./bmr/types";
+export {
+  calculateMifflinStJeor,
+  calculateKatchMcArdle,
+  calculateHarrisBenedict,
+} from "./bmr/index";
+export type {
+  MifflinStJeorInput,
+  KatchMcArdleInput,
+  HarrisBenedictInput,
+} from "./bmr/types";
 
 // TDEE formulas
 export { calculateTDEE } from "./tdee/index";


### PR DESCRIPTION
## Summary
- export calculateHarrisBenedict from core functions
- add Harris-Benedict route and calculator page
- create Harris-Benedict form and user values components
- include Harris-Benedict test case
- link new calculator from dashboard

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858142169b48326880e1e7f7941b75d