### PR TITLE
Fix layout overflow issues

### DIFF
--- a/src/features/formulas/bmr/Harris/HarrisBenedictPage.module.scss
+++ b/src/features/formulas/bmr/Harris/HarrisBenedictPage.module.scss
@@ -45,6 +45,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/features/formulas/bmr/Katch/KatchMcArdlePage.module.scss
+++ b/src/features/formulas/bmr/Katch/KatchMcArdlePage.module.scss
@@ -12,6 +12,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/features/formulas/bmr/Mifflin/MifflinStJeorPage.module.scss
+++ b/src/features/formulas/bmr/Mifflin/MifflinStJeorPage.module.scss
@@ -45,6 +45,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/features/formulas/bodyComposition/BodyCompositionPage.module.scss
+++ b/src/features/formulas/bodyComposition/BodyCompositionPage.module.scss
@@ -30,6 +30,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/features/formulas/macros/MacrosPage.module.scss
+++ b/src/features/formulas/macros/MacrosPage.module.scss
@@ -30,6 +30,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/features/formulas/micros/MicrosPage.module.scss
+++ b/src/features/formulas/micros/MicrosPage.module.scss
@@ -30,6 +30,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/features/formulas/tdee/TDEEPage.module.scss
+++ b/src/features/formulas/tdee/TDEEPage.module.scss
@@ -30,6 +30,8 @@
   min-height: 420px;
   transform-style: preserve-3d;
   perspective: 1000px;
+  display: grid;
+  overflow: hidden;
 }
 
 .face {

--- a/src/index.css
+++ b/src/index.css
@@ -56,6 +56,7 @@ body {
   transition: background-color 1s ease, color 0.3s ease;
   max-width: 100vw;
   background-color: var(--color-primary-800);
+  overflow-x: hidden;
 }
 
 * {


### PR DESCRIPTION
## Summary
- prevent horizontal scroll by hiding overflow on the body
- keep flip card content contained for calculators

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685934d6b428832699285f85a142bef2